### PR TITLE
feat: update beforeChangeSlug hook to ensure proper slug generation a…

### DIFF
--- a/src/payload/collections/Noticias.ts
+++ b/src/payload/collections/Noticias.ts
@@ -1,15 +1,16 @@
+import type { Noticia } from '@/payload-types'
 import { contenido } from '@/payload/fields/contenido'
 import type { CollectionConfig, FieldHook } from 'payload'
 import { isComunicacionOrAdminCollectionAccess, isPublicAccess } from '../access/collection'
 import { HIDE_API_URL } from '../config'
 
-const beforeChangeSlug: FieldHook = ({ value }) =>
-  value
-    ? value
-        .toLowerCase()
-        .replace(/\s+/g, '-')
-        .replace(/[^a-z0-9\-]/g, '')
-    : Date.now().toString()
+const beforeChangeSlug: FieldHook<Noticia> = ({ value }) => {
+  const slug = String(value || Date.now())
+  return slug
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\-]/g, '')
+}
 
 export const Noticias: CollectionConfig = {
   slug: 'noticias',
@@ -64,7 +65,7 @@ export const Noticias: CollectionConfig = {
       label: 'Slug',
       required: true,
       unique: true,
-      defaultValue: () => Date.now(),
+      defaultValue: () => Date.now().toString(),
       hooks: { beforeValidate: [beforeChangeSlug] },
     },
     {


### PR DESCRIPTION
This pull request updates the slug generation logic for the `Noticias` collection to ensure slugs are consistently formatted as strings and properly sanitized. The most important changes are:

Slug generation improvements:
* Updated the `beforeChangeSlug` hook to always return a string, even when the value is missing, and to sanitize the slug by lowercasing, replacing spaces with dashes, and removing invalid characters.
* Changed the `defaultValue` for the slug field to return a string representation of the current timestamp, ensuring the default slug is always a string.